### PR TITLE
Remove non-existing variable from example playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,6 @@ Example Playbook
 
     docker_userns_remap_enable: yes
     docker_userns_remap_user: userns-remap-user
-    docker_userns_remap_group: userns-remap-group
 
     docker_users:
       - docker-admin-1


### PR DESCRIPTION
Removed `docker_userns_remap_group` variable from example playbook in README.

Closes #52 