### PR TITLE
Clarify why /var/lib/docker volume is used

### DIFF
--- a/molecule/compose_binary/molecule.yml
+++ b/molecule/compose_binary/molecule.yml
@@ -12,6 +12,8 @@ platforms:
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      # Required for Docker in Docker. Default storage drivers (aufs/overlay2)
+      # don't support AUFS/OverlayFS backing filesystem.
       - /var/lib/docker
     keep_volumes: false
 provisioner:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -12,6 +12,8 @@ platforms:
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      # Required for Docker in Docker. Default storage drivers (aufs/overlay2)
+      # don't support AUFS/OverlayFS backing filesystem.
       - /var/lib/docker
     keep_volumes: false
 provisioner:

--- a/molecule/fix_iptables_rules/molecule.yml
+++ b/molecule/fix_iptables_rules/molecule.yml
@@ -12,6 +12,8 @@ platforms:
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      # Required for Docker in Docker. Default storage drivers (aufs/overlay2)
+      # don't support AUFS/OverlayFS backing filesystem.
       - /var/lib/docker
     keep_volumes: false
 provisioner:

--- a/molecule/userns_remap/molecule.yml
+++ b/molecule/userns_remap/molecule.yml
@@ -12,6 +12,8 @@ platforms:
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      # Required for Docker in Docker. Default storage drivers (aufs/overlay2)
+      # don't support AUFS/OverlayFS backing filesystem.
       - /var/lib/docker
     keep_volumes: false
 provisioner:


### PR DESCRIPTION
 Required for Docker in Docker. Default storage drivers (aufs/overlay2) don't support AUFS/OverlayFS backing filesystem.