### PR TITLE
Update testing requirements

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,6 +1,0 @@
----
-mock_roles:
-  # A workaround to bypass the following error:
-  # internal-error: the role '<...>' was not found in <...>
-  # See https://github.com/ansible/ansible-lint/issues/1329
-  - yabusygin.docker

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-_distribution: "{{ ansible_facts['distribution']|lower }}"
+_distribution: "{{ ansible_facts['distribution'] | lower }}"
 _release: "{{ ansible_facts['distribution_release'] }}"
 
 docker_apt_key_url: "https://download.docker.com/linux/{{ _distribution }}/gpg"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   author: Alexey Busygin
   description: An Ansible role installing Docker CE and Docker Compose.
   license: MIT
-  min_ansible_version: 2.7
+  min_ansible_version: "2.7"
   platforms:
     - name: Debian
       versions:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible>=5.0,<6.0
+ansible>=6.2,<6.3
 ansible-lint>=6.0,<6.1
 templtest>=0.2,<0.3
 requests>=2.0,<3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 ansible>=6.2,<6.3
 ansible-lint>=6.4,<6.5
 templtest>=0.2,<0.3
-molecule[docker,lint,test]>=3.6,<3.7
+molecule[docker,lint,test]>=4.0,<4.1
 
 # A workaround for the following issue:
 # https://github.com/ansible-community/molecule/issues/3404

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ansible>=6.2,<6.3
-ansible-lint>=6.0,<6.1
+ansible-lint>=6.4,<6.5
 templtest>=0.2,<0.3
 requests>=2.0,<3.0
 molecule[docker,lint,test]>=3.6,<3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 ansible>=6.2,<6.3
 ansible-lint>=6.4,<6.5
 templtest>=0.2,<0.3
-requests>=2.0,<3.0
 molecule[docker,lint,test]>=3.6,<3.7
 
 # A workaround for the following issue:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,3 @@ ansible>=6.2,<6.3
 ansible-lint>=6.4,<6.5
 templtest>=0.2,<0.3
 molecule[docker,lint,test]>=4.0,<4.1
-
-# A workaround for the following issue:
-# https://github.com/ansible-community/molecule/issues/3404
-ansible-compat>=2.0,<2.1


### PR DESCRIPTION
Testing requirements were updated to the following versions:

| Package | Version |
| --- | --- |
| ansible | 6.2 |
| ansible-lint | 6.4 |
| molecule | 4.0 |

The "requests" package following requirement was removed.

This updates have allowed to remove workarounds for the following issues:

- https://github.com/ansible-community/molecule/issues/3404
- https://github.com/ansible/ansible-lint/issues/1329