### PR TITLE
Update role metadata

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   role_name: docker
   namespace: yabusygin
   author: Alexey Busygin
-  description: An Ansible role installing Docker CE and Docker Compose.
+  description: An Ansible role installing Docker Engine and Docker Compose.
   license: MIT
   min_ansible_version: "2.7"
   platforms:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - focal
-        - bionic
+        - jammy
   galaxy_tags:
     - system
     - containerization

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   author: Alexey Busygin
   description: An Ansible role installing Docker Engine and Docker Compose.
   license: MIT
-  min_ansible_version: "2.7"
+  min_ansible_version: "2.10"
   platforms:
     - name: Debian
       versions:


### PR DESCRIPTION
Minimal Python version is set to 2.10. Updated list of supported Ubuntu distributions. Updated Docker product name (Docker CE -> Docker Engine) in role description.