### PR TITLE
Expanded variabless that did not follow naming convention

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,11 +1,8 @@
 ---
-_distribution: "{{ ansible_facts['distribution'] | lower }}"
-_release: "{{ ansible_facts['distribution_release'] }}"
-
-docker_apt_key_url: "https://download.docker.com/linux/{{ _distribution }}/gpg"
+docker_apt_key_url: "https://download.docker.com/linux/{{ ansible_facts['distribution'] | lower }}/gpg"
 docker_apt_sources_arch: amd64
-docker_apt_sources_uri: "https://download.docker.com/linux/{{ _distribution }}"
-docker_apt_sources_suite: "{{ _release }}"
+docker_apt_sources_uri: "https://download.docker.com/linux/{{ ansible_facts['distribution'] | lower }}"
+docker_apt_sources_suite: "{{ ansible_facts['distribution_release'] }}"
 
 docker_config:
   log-driver: json-file


### PR DESCRIPTION
Internal variables (`_distribution` and `_release`) that didn't follow naming convention (`docker_*`) have been expanded in order to omit possible name collisions with other roles or playbooks.