### PR TITLE
Use Ansible Core instead of Ansible Community

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
           python-version: "3.10"
 
       - name: install requirements
-        run: python -m pip install "ansible-core>=2.13,<2.14"
+        run: python -m pip install --requirement=requirements.txt
 
       - name: import role to Ansible Galaxy
         run: ansible-galaxy role import --api-key=${GALAXY_API_KEY} $(echo ${GITHUB_REPOSITORY} | cut -d/ -f1) $(echo ${GITHUB_REPOSITORY} | cut -d/ -f2)

--- a/requirements.ansible.txt
+++ b/requirements.ansible.txt
@@ -1,4 +1,4 @@
---requirement=requirements.ansible.txt
+ansible-core>=2.13,<2.14
 
 molecule[docker,test]>=4.0,<4.1
 ansible-lint>=6.4,<6.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible>=6.2,<6.3
+ansible-core>=2.13,<2.14
 
 molecule[docker,test]>=4.0,<4.1
 ansible-lint>=6.4,<6.5


### PR DESCRIPTION
Ansible Core package is bumped into development requirements instead of Ansible Community package. This change speeds up installation of the development requirements.