### PR TITLE
Install Ansible Core only while in release pipline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
           python-version: "3.10"
 
       - name: install requirements
-        run: python -m pip install --requirement=requirements.txt
+        run: python -m pip install --requirement=requirements.ansible.txt
 
       - name: import role to Ansible Galaxy
         run: ansible-galaxy role import --api-key=${GALAXY_API_KEY} $(echo ${GITHUB_REPOSITORY} | cut -d/ -f1) $(echo ${GITHUB_REPOSITORY} | cut -d/ -f2)

--- a/requirements.ansible.txt
+++ b/requirements.ansible.txt
@@ -1,9 +1,1 @@
 ansible-core>=2.13,<2.14
-
-molecule[docker,test]>=4.0,<4.1
-ansible-lint>=6.4,<6.5
-mypy==0.971
-pylint>=2.14,<2.15
-black>=22.6,<22.7
-
-templtest>=0.2,<0.3


### PR DESCRIPTION
The release pipeline mistakenly installed the same requirements as the test pipeline. The Ansible Core is the only requirement for the release pipeline. This PR fixes the described issue.