### PR TITLE
Enable caching of Python packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
         uses: actions/setup-python@v4.2.0
         with:
           python-version: "3.10"
+          cache: pip
+          cache-dependency-path: "**/requirements*.txt"
 
       - name: install requirements
         run: python -m pip install --requirement=requirements.ansible.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           python-version: "3.10"
           cache: pip
-          cache-dependency-path: "**/requirements*.txt"
+          cache-dependency-path: requirements*.txt
 
       - name: install requirements
         run: python -m pip install --requirement=requirements.ansible.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           python-version: "3.10"
           cache: pip
-          cache-dependency-path: "**/requirements*.txt"
+          cache-dependency-path: requirements*.txt
 
       - name: install requirements
         run: python -m pip install --requirement=requirements.txt
@@ -47,7 +47,7 @@ jobs:
         with:
           python-version: "3.10"
           cache: pip
-          cache-dependency-path: "**/requirements*.txt"
+          cache-dependency-path: requirements*.txt
 
       - name: install requirements
         run: python -m pip install --requirement=requirements.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
         uses: actions/setup-python@v4.2.0
         with:
           python-version: "3.10"
+          cache: pip
+          cache-dependency-path: "**/requirements*.txt"
 
       - name: install requirements
         run: python -m pip install --requirement=requirements.txt
@@ -44,6 +46,8 @@ jobs:
         uses: actions/setup-python@v4.2.0
         with:
           python-version: "3.10"
+          cache: pip
+          cache-dependency-path: "**/requirements*.txt"
 
       - name: install requirements
         run: python -m pip install --requirement=requirements.txt

--- a/requirements.ansible.txt
+++ b/requirements.ansible.txt
@@ -1,1 +1,1 @@
-ansible-core>=2.13,<2.14
+ansible-core==2.13.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 --requirement=requirements.ansible.txt
 
-molecule[docker,test]>=4.0,<4.1
-ansible-lint>=6.4,<6.5
+molecule[docker,test]==4.0.1
+ansible-lint==6.4.0
 mypy==0.971
-pylint>=2.14,<2.15
-black>=22.6,<22.7
+pylint==2.14.5
+black==22.6.0
 
-templtest>=0.2,<0.3
+templtest==0.2.11


### PR DESCRIPTION
Enable [caching][1] feature of "setup-python" GitHub action. This feature is supposed to speed up CI pipelines.

[1]: https://github.com/actions/setup-python/blob/f6795b163d3422199fb74e169e9dc477edf891b1/README.md#caching-packages-dependencies