### PR TITLE
Do not specify Python version in CI job name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: check-out repository
         uses: actions/checkout@v3.0.2
 
-      - name: set up Python 3.10
+      - name: set up Python
         uses: actions/setup-python@v4.2.0
         with:
           python-version: "3.10"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       - name: check-out repository
         uses: actions/checkout@v3.0.2
 
-      - name: set up Python 3.10
+      - name: set up Python
         uses: actions/setup-python@v4.2.0
         with:
           python-version: "3.10"
@@ -42,7 +42,7 @@ jobs:
       - name: check-out repository
         uses: actions/checkout@v3.0.2
 
-      - name: set up Python 3.10
+      - name: set up Python
         uses: actions/setup-python@v4.2.0
         with:
           python-version: "3.10"


### PR DESCRIPTION
When Python version (`with.python-version`) is updated, there is no need to
update the job name.