### PR TITLE
Update python package version constraints

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,7 +16,7 @@ docker_ansible_dependencies_apt:
   - python3-setuptools
   - python3-virtualenv
 docker_ansible_dependencies_pip:
-  - docker>=1.10.0
+  - docker>=1.8.0
   - PyYAML>=3.11
   - docker-compose>=1.7.0,<2.0.0
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,9 +16,9 @@ docker_ansible_dependencies_apt:
   - python3-setuptools
   - python3-virtualenv
 docker_ansible_dependencies_pip:
-  - docker>=1.8.0
+  - docker>=1.8
   - PyYAML>=3.11
-  - docker-compose>=1.7.0,<2.0.0
+  - docker-compose>=1.7,<2.0
 
 docker_iptables_check: yes
 docker_iptables_executable: iptables

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,7 +18,7 @@ docker_ansible_dependencies_apt:
 docker_ansible_dependencies_pip:
   - docker>=1.10.0
   - PyYAML>=3.11
-  - docker-compose>=1.7.0
+  - docker-compose>=1.7.0,<2.0.0
 
 docker_iptables_check: yes
 docker_iptables_executable: iptables


### PR DESCRIPTION
The role installs [some Python packages][1] that are required by Ansible modules for Docker. This PR updates version specifiers of these packages according to the recent version of [documentation][1].

[1]: https://docs.ansible.com/ansible/latest/collections/community/docker/docker_compose_module.html#requirements